### PR TITLE
Add X-Ray tracing to add-api API Gateway

### DIFF
--- a/services/app-api/serverless.yml
+++ b/services/app-api/serverless.yml
@@ -76,6 +76,8 @@ provider:
   region: us-east-1
   logs:
     restApi: true
+  tracing:
+    apiGateway: true
   iam:
     role:
       path: ${ssm:/configuration/${self:custom.stage}/iam/path, ssm:/configuration/default/iam/path, "/"}


### PR DESCRIPTION
## Purpose

Security Hub finding:
APIGateway.3: API Gateway REST API stages should have AWS X-Ray tracing enabled

#### Linked Issues to Close

https://qmacbis.atlassian.net/browse/OY2-22318

